### PR TITLE
fix: correct the generic type for either.FromIO

### DIFF
--- a/either/either.go
+++ b/either/either.go
@@ -33,7 +33,7 @@ func Of[E, A any](value A) Either[E, A] {
 	return F.Pipe1(value, Right[E, A])
 }
 
-func FromIO[E, IO ~func() A, A any](f IO) Either[E, A] {
+func FromIO[E any, IO ~func() A, A any](f IO) Either[E, A] {
 	return F.Pipe1(f(), Right[E, A])
 }
 

--- a/either/either_test.go
+++ b/either/either_test.go
@@ -71,7 +71,6 @@ func TestReduce(t *testing.T) {
 	assert.Equal(t, "foo", F.Pipe1(Left[string, string]("bar"), Reduce[string](s.Concat, "foo")))
 
 }
-
 func TestAp(t *testing.T) {
 	f := S.Size
 
@@ -119,4 +118,11 @@ func TestStringer(t *testing.T) {
 
 	var s fmt.Stringer = e
 	assert.Equal(t, exp, s.String())
+}
+
+func TestFromIO(t *testing.T) {
+	f := func() string { return "abc" }
+	e := FromIO[error](f)
+
+	assert.Equal(t, Right[error]("abc"), e)
 }


### PR DESCRIPTION
Fix the issue in changes https://github.com/IBM/fp-go/commit/e350f70659a1f02dca3c59003fbf6020fbedec0f#diff-4458e7e57693d8c5f87f48669e33d2874aeaae1c8d37fcda76204057d29b5bfaL16-L18

as function signature
``` go
FromIO[E, IO ~func() A, A any](f IO) Either[E, A]
```

The type `E` can't be same as type `IO`.