### PR TITLE
chore: ignore fp-go file for unix machine

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 fp-go.exe
+fp-go
 main.exe
 build/
 .idea


### PR DESCRIPTION
motivation:
when go build on unix machine(apple m2), it generate fp-go file, I notice that there is a line (fp-go.exe) on .gitignore
so also need a fp-go