### PR TITLE
refactor: replace interface{} with any (Go 1.18+)

### DIFF
--- a/v2/IDIOMATIC_COMPARISON.md
+++ b/v2/IDIOMATIC_COMPARISON.md
@@ -160,7 +160,7 @@ func bad1() *Either[error, int] {
 }
 
 // Storing in interface
-func bad2() interface{} {
+func bad2() any {
     return Right[error](42)  // ESCAPES: interface boxing
 }
 

--- a/v2/cli/lens.go
+++ b/v2/cli/lens.go
@@ -344,7 +344,7 @@ func getTypeName(expr ast.Expr) string {
 	case *ast.SelectorExpr:
 		return getTypeName(t.X) + "." + t.Sel.Name
 	case *ast.InterfaceType:
-		return "interface{}"
+		return "any"
 	case *ast.IndexExpr:
 		// Generic type with single type parameter (Go 1.18+)
 		// e.g., Option[string]

--- a/v2/cli/lens_test.go
+++ b/v2/cli/lens_test.go
@@ -212,7 +212,7 @@ func TestIsComparableType(t *testing.T) {
 		},
 		{
 			name:     "interface type",
-			code:     "type T struct { F interface{} }",
+			code:     "type T struct { F any }",
 			expected: true,
 		},
 		{

--- a/v2/function/type.go
+++ b/v2/function/type.go
@@ -56,11 +56,11 @@ type (
 //	_ = doSomething()
 var VOID Void = struct{}{}
 
-// ToAny converts a value of any type to the any (interface{}) type.
+// ToAny converts a value of any type to the any (any) type.
 //
 // This function performs an explicit type conversion to the any type, which can be
 // useful when you need to store values of different types in a homogeneous collection
-// or when interfacing with APIs that require any/interface{}.
+// or when interfacing with APIs that require any/any.
 //
 // Type Parameters:
 //   - A: The type of the input value

--- a/v2/ioresult/file/types.go
+++ b/v2/ioresult/file/types.go
@@ -70,9 +70,9 @@ type (
 	//   })
 	//
 	//   // An operator that validates JSON
-	//   var validateJSON Operator[string, map[string]interface{}] = ChainEitherK(
-	//       func(s string) Result[map[string]interface{}] {
-	//           var result map[string]interface{}
+	//   var validateJSON Operator[string, map[string]any] = ChainEitherK(
+	//       func(s string) Result[map[string]any] {
+	//           var result map[string]any
 	//           err := json.Unmarshal([]byte(s), &result)
 	//           return result.TryCatchError(result, err)
 	//       },

--- a/v2/json/json.go
+++ b/v2/json/json.go
@@ -147,10 +147,10 @@ func Marshal[A any](a A) Either[[]byte] {
 // Example with error handling:
 //
 //	type Config struct {
-//	    Settings map[string]interface{} `json:"settings"`
+//	    Settings map[string]any `json:"settings"`
 //	}
 //
-//	config := Config{Settings: map[string]interface{}{"debug": true}}
+//	config := Config{Settings: map[string]any{"debug": true}}
 //	result := json.MarshalIndent(config)
 //
 //	either.Fold(

--- a/v2/optics/codec/format.go
+++ b/v2/optics/codec/format.go
@@ -72,11 +72,11 @@ func (t *typeImpl[A, O, I]) LogValue() slog.Value {
 }
 
 // typeNameOf returns a string representation of the type T.
-// It handles the special case where T is 'any' (interface{}).
+// It handles the special case where T is 'any' (any).
 func typeNameOf[T any]() string {
 	var zero T
 	typeName := fmt.Sprintf("%T", zero)
-	// Handle the case where %T prints "<nil>" for interface{} types
+	// Handle the case where %T prints "<nil>" for any types
 	if typeName == "<nil>" {
 		return "interface {}"
 	}

--- a/v2/optics/prism/prisms.go
+++ b/v2/optics/prism/prisms.go
@@ -129,7 +129,7 @@ func ParseURL() Prism[string, *url.URL] {
 	)
 }
 
-// InstanceOf creates a prism for type assertions on interface{}/any values.
+// InstanceOf creates a prism for type assertions on any/any values.
 // It provides a safe way to extract values of a specific type from an any value,
 // handling type mismatches gracefully through the Option type.
 //
@@ -165,10 +165,10 @@ func ParseURL() Prism[string, *url.URL] {
 //	result := setter(intPrism)(any(42))  // any(100)
 //
 // Common use cases:
-//   - Safely extracting typed values from interface{} collections
+//   - Safely extracting typed values from any collections
 //   - Working with heterogeneous data structures
 //   - Type-safe deserialization and validation
-//   - Pattern matching on interface{} values
+//   - Pattern matching on any values
 func InstanceOf[T any]() Prism[any, T] {
 	var t T
 	return MakePrismWithName(option.InstanceOf[T], F.ToAny[T], fmt.Sprintf("PrismInstanceOf[%T]", t))

--- a/v2/result/either.go
+++ b/v2/result/either.go
@@ -612,7 +612,7 @@ func Zero[A any]() Result[A] {
 // If the type assertion succeeds, it returns a Right containing the converted value.
 // If the type assertion fails, it returns a Left containing an error describing the type mismatch.
 //
-// This function is useful for safely converting interface{}/any values to concrete types
+// This function is useful for safely converting any/any values to concrete types
 // in a functional programming style, where type assertion failures are represented as
 // Left values rather than panics or boolean checks.
 //


### PR DESCRIPTION
Replace `interface{}` with `any` for Go 1.18+ compatibility.

This is a mechanical refactoring using the modern `any` alias introduced in Go 1.18.
Only the empty interface type literal was replaced; interface definitions with methods are left unchanged.