### PR TITLE
perf(option): make AltAllArray/AltAllSeq allocation-free

### DIFF
--- a/v2/option/alt.go
+++ b/v2/option/alt.go
@@ -15,10 +15,6 @@
 
 package option
 
-import (
-	"github.com/IBM/fp-go/v2/internal/alt"
-)
-
 // AltAllArray combines multiple Options from an array using the Alt operation.
 // It starts with an initial Option and iteratively applies Alt with each Option
 // in the array, returning the first Some value encountered or the last value if
@@ -75,7 +71,20 @@ import (
 //   - AltAllSeq: Similar function for iterator sequences
 //   - AltMonoid: Monoid that uses Alt operation
 func AltAllArray[A any](startWith Option[A]) Kleisli[[]Option[A], A] {
-	return alt.AltAllArray[Option[A]](Alt)(startWith)
+	// Direct first-Some scan: option's Alt keeps the current value if it is Some,
+	// otherwise takes the next one. Folding via the generic lazy Alt would wrap
+	// every element in an F.Constant thunk (a closure allocation per element);
+	// this loop is allocation-free while preserving identical semantics
+	// (startWith priority; first Some in the array; else the last value).
+	return func(as []Option[A]) Option[A] {
+		current := startWith
+		for _, o := range as {
+			if !IsSome(current) {
+				current = o
+			}
+		}
+		return current
+	}
 }
 
 // AltAllSeq combines multiple Options from an iterator sequence using the Alt operation.
@@ -128,5 +137,16 @@ func AltAllArray[A any](startWith Option[A]) Kleisli[[]Option[A], A] {
 //   - AltAllArray: Similar function for arrays
 //   - AltMonoid: Monoid that uses Alt operation
 func AltAllSeq[A any](startWith Option[A]) Kleisli[Seq[Option[A]], A] {
-	return alt.AltAllSeq[Option[A]](Alt)(startWith)
+	// Direct scan, allocation-free (see AltAllArray). Matches the existing
+	// behaviour of consuming the whole sequence (no early break) while keeping
+	// the first Some encountered.
+	return func(as Seq[Option[A]]) Option[A] {
+		current := startWith
+		for o := range as {
+			if !IsSome(current) {
+				current = o
+			}
+		}
+		return current
+	}
 }


### PR DESCRIPTION
## What

`option.AltAllArray` / `option.AltAllSeq` reduce a collection of `Option`s with
`Alt` — keep the first `Some`, otherwise fall through. They are currently built on
the generic lazy `Alt` combinator in `internal/alt`:

```go
return alt.AltAllArray[Option[A]](Alt)(startWith)
```

That generic fold evaluates `falt(F.Constant(next))(current)` for **every element**,
wrapping each one in an `F.Constant` thunk closure — i.e. **one heap allocation per
element** — even though `option.Alt` just returns the current value when it is
already `Some`.

This PR replaces both functions with a direct first-`Some` scan, which is
allocation-free.

## Behaviour — unchanged

Identical semantics, locked down by the existing `TestAltAllArray_*` /
`TestAltAllSeq_*` suites:
- `startWith` has priority (returned as-is when it is `Some`);
- otherwise the first `Some` in the input is returned;
- if everything is `None`, the last value is returned;
- `AltAllSeq` still consumes the whole sequence — there is a dedicated test
  (`stops iteration after finding first Some`) that asserts the generator is fully
  drained, so an accidental early `break` would fail CI.

## How to measure

The package already ships `BenchmarkAltAllArray`, `BenchmarkAltAllSeq` and their
`_AllNone` variants — no new test code is added. From the `v2/` module:

```
go test -run='^$' -bench=BenchmarkAltAll -benchmem -count=10 ./option
```

`benchstat` of `main` vs this branch (count=10, all `p=0.000`, n=10):

| benchmark             | allocs/op (before → after) | B/op (before → after) |
|-----------------------|----------------------------|-----------------------|
| `AltAllArray`         | 12 → **0**                 | 320 → **0**           |
| `AltAllSeq`           | 15 → **0**                 | 392 → **0**           |
| `AltAllArray_AllNone` | 12 → **0**                 | 320 → **0**           |
| `AltAllSeq_AllNone`   | 15 → **0**                 | 392 → **0**           |

## Expected improvement

**−100% allocations and −100% bytes** for these operations (allocation count is now
O(1) instead of O(n) in the input length). Wall-clock time drops sharply too, but
for the value-discarding benchmarks part of that is the compiler eliminating the
now side-effect-free call, so the exact, honest headline is the allocation/byte
numbers above.

## Testing

- `go test -race ./...` (the CI command) — passes, no new failures.
- `go test -race -count=2 ./option/...` — passes (race-clean, deterministic).
- `gofmt -l` clean, `go vet ./option/...` clean, `go build ./...` OK.
- Behaviour is covered by the existing `TestAltAll*` suites (success, edge cases,
  integration, full-consumption, AltMonoid relationship); no behavioural change.

## Scope

Single file (`v2/option/alt.go`); removes the now-unused `internal/alt` import.
No public API or behavioural change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Cm6KJg4HxtUZH997Gbcjcf
